### PR TITLE
Publish v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.12.0] - 2026-02-02
 ### Fixed
 - Fixed a panic when drawing small anti-aliased rectangles. Thanks to [@nwhitehead](https://github.com/nwhitehead)
 
@@ -270,7 +272,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Bindings to a stripped down Skia fork.
 
-[Unreleased]: https://github.com/linebender/tiny-skia/compare/v0.11.4...HEAD
+[Unreleased]: https://github.com/linebender/tiny-skia/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/linebender/tiny-skia/compare/v0.11.4...v0.12.0
 [0.11.4]: https://github.com/linebender/tiny-skia/compare/v0.11.3...v0.11.4
 [0.11.3]: https://github.com/linebender/tiny-skia/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/linebender/tiny-skia/compare/v0.11.1...v0.11.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-skia"
-version = "0.11.4"
+version = "0.12.0"
 authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
 edition = "2021"
 description = "A tiny Skia subset ported to Rust."
@@ -21,7 +21,7 @@ bytemuck = { version = "1.24", features = ["aarch64_simd"] }
 cfg-if = "1"
 log = "0.4"
 png = { version = "0.18", optional = true }
-tiny-skia-path = { version = "0.11.4", path = "path", default-features = false }
+tiny-skia-path = { version = "0.12.0", path = "path", default-features = false }
 
 [features]
 default = ["std", "simd", "png-format"]

--- a/path/Cargo.toml
+++ b/path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-skia-path"
-version = "0.11.4"
+version = "0.12.0"
 authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
 edition = "2021"
 description = "A tiny-skia Bezier path implementation"


### PR DESCRIPTION
Update version numbers and changelog for v0.12.0 release.

`cargo-semver-checks` says that `tiny-skia-path` also requires a semver-breaking release (and it looks like historically it's version has been locked to that of `tiny-skia` anyway), so I've also updated it's version number.