### PR TITLE
perf: AVX2 gather for PixmapRef::gather

### DIFF
--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -155,33 +155,9 @@ impl PixmapRef<'_> {
     #[inline(always)]
     pub(crate) fn gather(&self, index: u32x8) -> [PremultipliedColorU8; highp::STAGE_WIDTH] {
         let pixels = self.pixels();
-        cfg_if::cfg_if! {
-            if #[cfg(all(feature = "simd", target_feature = "avx2"))] {
-                #[cfg(target_arch = "x86")]
-                use core::arch::x86::*;
-                #[cfg(target_arch = "x86_64")]
-                use core::arch::x86_64::*;
-
-                // gather faults on oob; callers clamp indices to [0, w*h) via gather_ix.
-                unsafe {
-                    let vindex: __m256i = bytemuck::cast(index);
-                    let gathered = _mm256_i32gather_epi32::<4>(pixels.as_ptr() as *const i32, vindex);
-                    bytemuck::cast(gathered)
-                }
-            } else {
-                let index: [u32; 8] = bytemuck::cast(index);
-                [
-                    pixels[index[0] as usize],
-                    pixels[index[1] as usize],
-                    pixels[index[2] as usize],
-                    pixels[index[3] as usize],
-                    pixels[index[4] as usize],
-                    pixels[index[5] as usize],
-                    pixels[index[6] as usize],
-                    pixels[index[7] as usize],
-                ]
-            }
-        }
+        // safety: callers clamp indices to [0, w*h) via gather_ix.
+        let gathered = unsafe { u32x8::gather_u32(pixels.as_ptr() as *const u32, index) };
+        bytemuck::cast(gathered)
     }
 }
 

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -154,18 +154,34 @@ pub const STAGES_COUNT: usize = Stage::GammaCompressSrgb as usize + 1;
 impl PixmapRef<'_> {
     #[inline(always)]
     pub(crate) fn gather(&self, index: u32x8) -> [PremultipliedColorU8; highp::STAGE_WIDTH] {
-        let index: [u32; 8] = bytemuck::cast(index);
         let pixels = self.pixels();
-        [
-            pixels[index[0] as usize],
-            pixels[index[1] as usize],
-            pixels[index[2] as usize],
-            pixels[index[3] as usize],
-            pixels[index[4] as usize],
-            pixels[index[5] as usize],
-            pixels[index[6] as usize],
-            pixels[index[7] as usize],
-        ]
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "simd", target_feature = "avx2"))] {
+                #[cfg(target_arch = "x86")]
+                use core::arch::x86::*;
+                #[cfg(target_arch = "x86_64")]
+                use core::arch::x86_64::*;
+
+                // gather faults on oob; callers clamp indices to [0, w*h) via gather_ix.
+                unsafe {
+                    let vindex: __m256i = bytemuck::cast(index);
+                    let gathered = _mm256_i32gather_epi32::<4>(pixels.as_ptr() as *const i32, vindex);
+                    bytemuck::cast(gathered)
+                }
+            } else {
+                let index: [u32; 8] = bytemuck::cast(index);
+                [
+                    pixels[index[0] as usize],
+                    pixels[index[1] as usize],
+                    pixels[index[2] as usize],
+                    pixels[index[3] as usize],
+                    pixels[index[4] as usize],
+                    pixels[index[5] as usize],
+                    pixels[index[6] as usize],
+                    pixels[index[7] as usize],
+                ]
+            }
+        }
     }
 }
 

--- a/src/wide/u32x8_t.rs
+++ b/src/wide/u32x8_t.rs
@@ -81,6 +81,34 @@ impl u32x8 {
             }
         }
     }
+
+    /// Gathers 8 u32s from `base[index[i]]`.
+    ///
+    /// # Safety
+    /// Each lane in `index` must be a valid offset (in u32 units) into the
+    /// buffer at `base`. avx2 `vpgatherdd` faults on oob; the scalar fallback
+    /// indexes a raw slice and would UB on oob too.
+    #[inline(always)]
+    pub unsafe fn gather_u32(base: *const u32, index: Self) -> Self {
+        cfg_if::cfg_if! {
+            if #[cfg(all(feature = "simd", target_feature = "avx2"))] {
+                let vindex: __m256i = cast(index);
+                Self(_mm256_i32gather_epi32::<4>(base as *const i32, vindex))
+            } else {
+                let ix: [u32; 8] = bytemuck::cast(index);
+                bytemuck::cast([
+                    *base.add(ix[0] as usize),
+                    *base.add(ix[1] as usize),
+                    *base.add(ix[2] as usize),
+                    *base.add(ix[3] as usize),
+                    *base.add(ix[4] as usize),
+                    *base.add(ix[5] as usize),
+                    *base.add(ix[6] as usize),
+                    *base.add(ix[7] as usize),
+                ])
+            }
+        }
+    }
 }
 
 impl core::ops::Not for u32x8 {


### PR DESCRIPTION
This PR is part of a series linked to #174.

## What

Replaces 8 scalar pixel loads in `PixmapRef::gather` with `_mm256_i32gather_epi32` (on AVX2). Again gated on `feature = "simd", target_feature = "avx2"`, meaning SSE2/SSE4.1/AVX, Neon etc. are unchanged. 

## Why

Image sampling takes a hard hit from `gather`, because bicubic patterns make 16 sample calls per pix batch, each loading 8 pixels. One AVX2 gather replaces 8 dependent scalar loads. 

## Results

| | speedup |
|---|---|
| Geomean (56 benches) | 1.04x |
| `patterns::hq` (bicubic) | 1.44x |
| `patterns::lq` (bilinear) | 1.33x |
| `patterns::plain` (nearest) | 1.18x |
| `fill::rect`, `hairline`, `blend::destination_over` (don't hit gather) | 1.00x |

No regressions. A bunch of unrelated benches landed at ~1.1x, probably just noise/variance. 

## Notes

- `_mm256_i32gather_epi32` does no bounds check; callers camp indices to `[0, w*h]` so the invariant holds
- Style-wise inspired by existing `src/wide/i32x8_t.rs` / `u32x8_t.rs`
- Only seen when built with `-Ctarget-cpu=haswell`, `-Ctarget-feature=+avx2` or `target-cpu=native`
- Benched on i5-13400F (raptor lake). Since gather is microcoded, the win on Zen 1/2 may be smaller or nothing at all. Still shouldn't regress.