### PR TITLE
fix: change the to_int_rect method

### DIFF
--- a/examples/image_on_image.rs
+++ b/examples/image_on_image.rs
@@ -10,14 +10,16 @@ fn main() {
     let mut paint = PixmapPaint::default();
     paint.quality = FilterQuality::Bicubic;
 
-    pixmap.draw_pixmap(
-        20,
-        20,
-        triangle.as_ref(),
-        &paint,
-        Transform::from_row(1.2, 0.5, 0.5, 1.2, 0.0, 0.0),
-        None,
-    );
+    pixmap
+        .draw_pixmap(
+            20,
+            20,
+            triangle.as_ref(),
+            &paint,
+            Transform::from_row(1.2, 0.5, 0.5, 1.2, 0.0, 0.0),
+            None,
+        )
+        .unwrap();
 
     println!(
         "Rendered in {:.2}ms",

--- a/path/src/size.rs
+++ b/path/src/size.rs
@@ -84,8 +84,8 @@ impl IntSize {
     }
 
     /// Converts into [`IntRect`] at the provided position.
-    pub fn to_int_rect(&self, x: i32, y: i32) -> IntRect {
-        IntRect::from_xywh(x, y, self.width(), self.height()).unwrap()
+    pub fn to_int_rect(&self, x: i32, y: i32) -> Option<IntRect> {
+        IntRect::from_xywh(x, y, self.width(), self.height())
     }
 }
 

--- a/path/src/size.rs
+++ b/path/src/size.rs
@@ -117,7 +117,7 @@ mod tests {
 
         let size = IntSize::from_wh(3, 4).unwrap();
         assert_eq!(
-            size.to_int_rect(1, 2),
+            size.to_int_rect(1, 2).unwrap(),
             IntRect::from_xywh(1, 2, 3, 4).unwrap()
         );
     }

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -146,7 +146,7 @@ impl Mask {
     }
 
     pub(crate) fn submask(&self, rect: IntRect) -> Option<SubMaskRef<'_>> {
-        let rect = self.size.to_int_rect(0, 0).intersect(&rect)?;
+        let rect = self.size.to_int_rect(0, 0)?.intersect(&rect)?;
         let row_bytes = self.width() as usize;
         let offset = rect.top() as usize * row_bytes + rect.left() as usize;
 
@@ -166,7 +166,7 @@ impl Mask {
     }
 
     pub(crate) fn subpixmap(&mut self, rect: IntRect) -> Option<SubPixmapMut<'_>> {
-        let rect = self.size.to_int_rect(0, 0).intersect(&rect)?;
+        let rect = self.size.to_int_rect(0, 0)?.intersect(&rect)?;
         let row_bytes = self.width() as usize;
         let offset = rect.top() as usize * row_bytes + rect.left() as usize;
 

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -160,9 +160,9 @@ impl Pixmap {
         paint: &PixmapPaint,
         transform: Transform,
         mask: Option<&Mask>,
-    ) {
+    ) -> std::io::Result<()> {
         self.as_mut()
-            .draw_pixmap(x, y, pixmap, paint, transform, mask);
+            .draw_pixmap(x, y, pixmap, paint, transform, mask)
     }
 
     /// Applies a masks.
@@ -477,8 +477,15 @@ impl PixmapMut<'_> {
         paint: &PixmapPaint,
         transform: Transform,
         mask: Option<&Mask>,
-    ) {
-        let rect = pixmap.size().to_int_rect(x, y).to_rect();
+    ) -> std::io::Result<()> {
+        let rect = pixmap
+            .size()
+            .to_int_rect(x, y)
+            .ok_or(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Cannot convert the size to a rect",
+            ))?
+            .to_rect();
 
         // TODO: SkSpriteBlitter
         // TODO: partially clipped
@@ -502,6 +509,7 @@ impl PixmapMut<'_> {
         };
 
         self.fill_rect(rect, &paint, transform, mask);
+        Ok(())
     }
 
     /// Applies a masks.

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -28,7 +28,8 @@ pub enum FillRule {
     EvenOdd,
 }
 
-#[derive(Debug)]
+/// Invalid Size
+#[derive(Debug, Copy)]
 pub struct InvalidSize;
 
 /// Controls how a shape should be painted.

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -28,6 +28,9 @@ pub enum FillRule {
     EvenOdd,
 }
 
+#[derive(Debug)]
+pub struct InvalidSize;
+
 /// Controls how a shape should be painted.
 #[derive(Clone, PartialEq, Debug)]
 pub struct Paint<'a> {
@@ -160,7 +163,7 @@ impl Pixmap {
         paint: &PixmapPaint,
         transform: Transform,
         mask: Option<&Mask>,
-    ) -> std::io::Result<()> {
+    ) -> Result<(), InvalidSize> {
         self.as_mut()
             .draw_pixmap(x, y, pixmap, paint, transform, mask)
     }
@@ -477,14 +480,11 @@ impl PixmapMut<'_> {
         paint: &PixmapPaint,
         transform: Transform,
         mask: Option<&Mask>,
-    ) -> std::io::Result<()> {
+    ) -> Result<(), InvalidSize> {
         let rect = pixmap
             .size()
             .to_int_rect(x, y)
-            .ok_or(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Cannot convert the size to a rect",
-            ))?
+            .ok_or(InvalidSize)?
             .to_rect();
 
         // TODO: SkSpriteBlitter

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -29,7 +29,7 @@ pub enum FillRule {
 }
 
 /// Invalid Size
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct InvalidSize;
 
 /// Controls how a shape should be painted.

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -542,7 +542,7 @@ impl<'a> PixmapMut<'a> {
     ///
     /// Returns `None` when `Pixmap`'s rect doesn't contain `rect`.
     pub(crate) fn subpixmap(&mut self, rect: IntRect) -> Option<SubPixmapMut<'_>> {
-        let rect = self.size.to_int_rect(0, 0).intersect(&rect)?;
+        let rect = self.size.to_int_rect(0, 0)?.intersect(&rect)?;
         let row_bytes = self.width() as usize * BYTES_PER_PIXEL;
         let offset = rect.top() as usize * row_bytes + rect.left() as usize * BYTES_PER_PIXEL;
 

--- a/tests/integration/mask.rs
+++ b/tests/integration/mask.rs
@@ -129,7 +129,7 @@ fn skip_dest() {
     mask.fill_path(&clip_path, FillRule::Winding, true, Transform::default());
 
     pixmap.draw_pixmap(0, 0, pixmap2.as_ref(), &PixmapPaint::default(),
-                                Transform::identity(), Some(&mask));
+                                Transform::identity(), Some(&mask)).unwrap();
 
     let expected = Pixmap::load_png("tests/images/mask/skip-dest.png").unwrap();
     assert_eq!(pixmap, expected);

--- a/tests/integration/pixmap.rs
+++ b/tests/integration/pixmap.rs
@@ -95,7 +95,7 @@ fn draw_pixmap() {
     paint.quality = FilterQuality::Bicubic;
 
     let mut pixmap = Pixmap::new(200, 200).unwrap();
-    pixmap.draw_pixmap(20, 20, sub_pixmap.as_ref(), &paint, Transform::identity(), None);
+    pixmap.draw_pixmap(20, 20, sub_pixmap.as_ref(), &paint, Transform::identity(), None).unwrap();
 
     let expected = Pixmap::load_png("tests/images/canvas/draw-pixmap.png").unwrap();
     assert_eq!(pixmap, expected);
@@ -130,7 +130,7 @@ fn draw_pixmap_ts() {
         &paint,
         Transform::from_row(1.2, 0.5, 0.5, 1.2, 0.0, 0.0),
         None,
-    );
+    ).unwrap();
 
     let expected = Pixmap::load_png("tests/images/canvas/draw-pixmap-ts.png").unwrap();
     assert_eq!(pixmap, expected);
@@ -166,7 +166,7 @@ fn draw_pixmap_opacity() {
         &paint,
         Transform::from_row(1.2, 0.5, 0.5, 1.2, 0.0, 0.0),
         None,
-    );
+    ).unwrap();
 
     let expected = Pixmap::load_png("tests/images/canvas/draw-pixmap-opacity.png").unwrap();
     assert_eq!(pixmap, expected);


### PR DESCRIPTION
The `to_int_rect` uses an unwrap that can crash because the method `from_xywh` is converting i32 to u32

```
pub fn from_xywh(x: i32, y: i32, width: u32, height: u32) -> Option<Self> {                                                                                                         
    x.checked_add(i32::try_from(width).ok()?)?;                                                                                                                                     
    y.checked_add(i32::try_from(height).ok()?)?;
```

I think `to_int_rect` should return `Option<IntSize>`


Note:
- right now, this is a breaking change, but it can be a non-breaking change if we add a `safe_to_int_rect` method instead
- `i32` range is `-2_147_483_648i32 => 2_147_483_647i32`
- `u32` range is `0u32 => 4_294_967_295u32`
- Related to https://github.com/linebender/resvg/issues/937